### PR TITLE
Add getXml() to AbstractValue

### DIFF
--- a/src/CommerceMLParser/Model/Types/AbstractValue.php
+++ b/src/CommerceMLParser/Model/Types/AbstractValue.php
@@ -15,9 +15,12 @@ abstract class AbstractValue
     protected $name;
     /** @var  string */
     protected $value;
+    /** @var \SimpleXMLElement  */
+    protected $_xml;
 
     public function __construct(\SimpleXMLElement $xml)
     {
+        $this->_xml = $xml;
         $this->name = (string)$xml->Наименование;
         $this->value = (string)$xml->Значение;
     }
@@ -36,5 +39,13 @@ abstract class AbstractValue
     public function getValue()
     {
         return $this->value;
+    }
+
+    /**
+     * @return \SimpleXMLElement
+     */
+    public function getXml()
+    {
+        return $this->_xml;
     }
 }


### PR DESCRIPTION
Вот тут у тебя есть 
![https://goo.gl/dCFrxn](https://goo.gl/dCFrxn)

А в `AbstractValue` не было, хотя этот `AbstractValue` тоже из XML состоит.

Я вот лично сделал у себя обработку ошибок единую и она там вызывает getXML и его в Exception потом кидает, удобно. Я думаю этот код тебе не помешает, а будет работать удобнее. Сделай мердж плиз.